### PR TITLE
Fix broken links, headers, and image in root readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ RPCs are used to help us understand where an object is within a plane when takin
 
 The code is well documented both inline and in the documentation files in this repo.
 
-![RPCs Explained] (https://github.com/ngageoint/Rational-Polynomial-Coefficients-Mapper/blob/master/RPCsExplained.png)
+![RPCs Explained](https://github.com/ngageoint/Rational-Polynomial-Coefficients-Mapper/blob/master/RPCsExplained.png)
 
-##Origin
-The RPC software was developed at the National Geospatial-Intelligence Agency (NGA) in collaboration with Booz Allen.  The government has "unlimited rights" and is releasing this software to increase the impact of government investments by providing developers with the opportunity to take things in new directions. The software use, modification, and distribution rights are stipulated within the [MIT] (http://choosealicense.com/licenses/mit/) license.  
+## Origin
+The RPC software was developed at the National Geospatial-Intelligence Agency (NGA) in collaboration with Booz Allen.  The government has "unlimited rights" and is releasing this software to increase the impact of government investments by providing developers with the opportunity to take things in new directions. The software use, modification, and distribution rights are stipulated within the [MIT](http://choosealicense.com/licenses/mit/) license.
 
-###Pull Requests
+### Pull Requests
 If you'd like to contribute to this project, please make a pull request. We'll review the pull request and discuss the changes. All pull request contributions to this project will be released under the MIT license.  
 
 Software source code previously released under an open source license and then modified by NGA staff is considered a "joint work" (see 17 USC § 101); it is partially copyrighted, partially public domain, and as a whole is protected by the copyrights of the non-government authors and must be released according to the terms of the original open source license.


### PR DESCRIPTION
I happened upon this repository while double checking my RPC math, and I noticed that the root `README.md` had a few issues:

- Added spaces between `#` and header text.
- Remove space between `[alt_txt] (url)`
